### PR TITLE
fix(docs): Update typos in public copy

### DIFF
--- a/src/Browse.svelte
+++ b/src/Browse.svelte
@@ -40,7 +40,7 @@
     <div class="flex flex-col pb-8">
       <h3 class="text-xl">Example Browser</h3>
       <p class="text-xs mb-2">
-        This view allows you to explore the curate collection of example programs for each of the languages.
+        This view allows you to explore the curated collection of example programs for each of the languages.
       </p>
       <div class="">
         <label for="lang-sort" class="text-xs font-bold">Sort by</label>

--- a/src/Content.svelte
+++ b/src/Content.svelte
@@ -109,10 +109,10 @@
           <a href="https://osf.io/e9v8y" target="_blank" class="text-sky-600 visited:text-sky-600 underline">
             this OSF link.
           </a>
-          Materials are also accessibile through the github page for this project (<a
+          Materials are also accessible through the github page for this project (<a
             class="text-sky-600 visited:text-sky-600 underline"
             href="https://github.com/mcnuttandrew/no-grammar-supplement">found here</a
-          >) and are completely equivalant to those hosted on OSF.
+          >) and are completely equivalent to those hosted on OSF.
         </p>
       </div>
       <div class="flex flex-col text-2xl pb-64">

--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -44,8 +44,8 @@
         <h5 class="text-lg">Showing {results.length} results</h5>
       {/if}
       <p class="mb-2">
-        This interfaces allows you to search the text of example programs. This can be useful if you are
-        trying to identify the prescence of a certain feature.
+        This interface allows you to search the text of example programs. This can be useful if you are
+        trying to identify the presence of a certain feature.
       </p>
     </div>
     <div class="flex">

--- a/src/SummaryView.svelte
+++ b/src/SummaryView.svelte
@@ -121,7 +121,7 @@
       </div>
     </div>
     <div class={exampleContainer}>
-      <div>Frequnecy of mark types</div>
+      <div>Frequency of mark types</div>
       <div class="text-xs">
         Note that these are the self reported mark type names by each of the languages
       </div>


### PR DESCRIPTION
## Motivation

Noticed a few small typos while reviewing the supplemental website for a research project

## Changes

No functional changes or stylistic updates, just modified a few words that stood out to me.

Wasn't sure if `Occurange` on the summary chart page was a portmanteau (range of occurrences) or a typo, so I left it alone